### PR TITLE
Fix the execution of ANISymmetryFunctions on a non-default CUDA stream

### DIFF
--- a/src/ani/CudaANISymmetryFunctions.cu
+++ b/src/ani/CudaANISymmetryFunctions.cu
@@ -100,6 +100,10 @@ void CudaANISymmetryFunctions::setStream(cudaStream_t stream) {
     this->stream = stream;
 }
 
+cudaStream_t CudaANISymmetryFunctions::getStream() const {
+    return stream;
+}
+
 template <bool PERIODIC, bool TRICLINIC>
 __device__ void computeDisplacement(float3 pos1, float3 pos2, float3& delta, float& r2, const float* periodicBoxVectors, float3 invBoxSize) {
     delta.x = pos2.x-pos1.x;

--- a/src/ani/CudaANISymmetryFunctions.h
+++ b/src/ani/CudaANISymmetryFunctions.h
@@ -80,9 +80,17 @@ public:
      */
     void backprop(const float* radialDeriv, const float* angularDeriv, float* positionDeriv);
     /**
-     * TODO
+     * Set the CUDA stream. By default, it is set to 0, which means the default stream.
+     *
+     * @param stream a CUDA stream object
      */
     void setStream(cudaStream_t stream);
+    /**
+     * Get the CUDA stream.
+     *
+     * @return a CUDA stream object
+     */
+    cudaStream_t getStream() const;
 private:
     int* neighbors;
     int* neighborCount;

--- a/src/ani/CudaANISymmetryFunctions.h
+++ b/src/ani/CudaANISymmetryFunctions.h
@@ -24,6 +24,7 @@
  * SOFTWARE.
  */
 
+#include <cuda_runtime.h>
 #include "ANISymmetryFunctions.h"
 
 class CudaANISymmetryFunctions : public ANISymmetryFunctions {
@@ -78,6 +79,10 @@ public:
      * @param positionDeriv    an array of shape [numAtoms][3] to store the derivative of E with respect to the atom positions into
      */
     void backprop(const float* radialDeriv, const float* angularDeriv, float* positionDeriv);
+    /**
+     * TODO
+     */
+    void setStream(cudaStream_t stream);
 private:
     int* neighbors;
     int* neighborCount;
@@ -92,6 +97,7 @@ private:
     float* positionDerivValues;
     bool triclinic;
     int maxBlocks;
+    cudaStream_t stream;
 };
 
 #endif

--- a/src/pytorch/SymmetryFunctions.cpp
+++ b/src/pytorch/SymmetryFunctions.cpp
@@ -22,7 +22,6 @@
  */
 
 #include <stdexcept>
-#include <cuda_runtime.h>
 #include <torch/script.h>
 #include <c10/cuda/CUDAStream.h>
 #include "CpuANISymmetryFunctions.h"
@@ -113,8 +112,8 @@ public:
         }
 
         if (cudaSymFunc) {
-            cudaStream_t stream = torch::cuda::getCurrentCUDAStream(tensorOptions.device().index()).stream();
-            cudaSymFunc->setStream(stream);
+            const torch::cuda::CUDAStream stream = torch::cuda::getCurrentCUDAStream(tensorOptions.device().index());
+            cudaSymFunc->setStream(stream.stream());
         }
 
         symFunc->computeSymmetryFunctions(positions.data_ptr<float>(), periodicBoxVectorsPtr, radial.data_ptr<float>(), angular.data_ptr<float>());
@@ -128,8 +127,8 @@ public:
         const Tensor angularGrad = grads[1].clone();
 
         if (cudaSymFunc) {
-            cudaStream_t stream = torch::cuda::getCurrentCUDAStream(tensorOptions.device().index()).stream();
-            cudaSymFunc->setStream(stream);
+            const torch::cuda::CUDAStream stream = torch::cuda::getCurrentCUDAStream(tensorOptions.device().index());
+            cudaSymFunc->setStream(stream.stream());
         }
 
         symFunc->backprop(radialGrad.data_ptr<float>(), angularGrad.data_ptr<float>(), positionsGrad.data_ptr<float>());

--- a/src/pytorch/SymmetryFunctions.cpp
+++ b/src/pytorch/SymmetryFunctions.cpp
@@ -113,7 +113,7 @@ public:
         }
 
         if (cudaSymFunc) {
-            stream = torch::cuda::getCurrentCUDAStream(positions.device().index()).stream();
+            cudaStream_t stream = torch::cuda::getCurrentCUDAStream(tensorOptions.device().index()).stream();
             cudaSymFunc->setStream(stream);
         }
 
@@ -128,6 +128,7 @@ public:
         const Tensor angularGrad = grads[1].clone();
 
         if (cudaSymFunc) {
+            cudaStream_t stream = torch::cuda::getCurrentCUDAStream(tensorOptions.device().index()).stream();
             cudaSymFunc->setStream(stream);
         }
 
@@ -147,7 +148,6 @@ private:
     Tensor angular;
     Tensor positionsGrad;
     CudaANISymmetryFunctions* cudaSymFunc;
-    cudaStream_t stream;
 };
 
 class AutogradFunctions : public torch::autograd::Function<AutogradFunctions> {


### PR DESCRIPTION
`ANISymmetryFunctions` give incorrect result if executed on a non-default stream.
- [x] Implement `CudaANISymmetryFunctions::setStream` and `CudaANISymmetryFunctions::getStream`
- [x] Set the CUDA stream in `NNPOps::ANISymmetryFunctions::Holder`
- [x] Add tests
- [x] Document