### PR TITLE
Test pytorch 1.10.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             gcc: 10.3.0
             nvcc: 11.2
             python: 3.9
-            pytorch: 1.10.0
+            pytorch: 1.10.2
           # Without CUDA
           - enable_cuda: false
             gcc: 10.3.0


### PR DESCRIPTION
I want to see what happens when using a newer pytorch.
I'm getting some errors on the conda-forge packaging side and I want to troubleshoot pytorch version issues, so this is only a test PR.