### PR TITLE
[DO NOT MERGE] Test if we can build with pytorch 1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             gcc: 10.3.0
             nvcc: 11.2
             python: 3.9
-            pytorch: 1.10.0
+            pytorch: 1.11
           # Without CUDA
           - enable_cuda: false
             gcc: 10.3.0


### PR DESCRIPTION
Running into this error when building with pytorch 1.11 on cuda 10, going to see if first we can build with 1.11