### PR TITLE
Fix the selection of the activation function in CFConv

### DIFF
--- a/src/pytorch/CFConv.cpp
+++ b/src/pytorch/CFConv.cpp
@@ -98,9 +98,9 @@ public:
 
             Activation activation_;
             if (activation == "ssp")
-                activation_ == ::CFConv::ShiftedSoftplus;
+                activation_ = ::CFConv::ShiftedSoftplus;
             else if (activation == "tanh")
-                activation_ == ::CFConv::Tanh;
+                activation_ = ::CFConv::Tanh;
             else
                 throw std::invalid_argument("Invalid value of \"activation\"");
 


### PR DESCRIPTION
`NNPOps.CFConv` used the shifted soft plus activation function regardless the value of the `activation` argument. 

- [x] Fix the selection of the activation function

Fixes #66 