### PR TITLE
Align SpeciesConverter return type with TorchANI version

### DIFF
--- a/src/pytorch/SpeciesConverter.py
+++ b/src/pytorch/SpeciesConverter.py
@@ -15,7 +15,11 @@
 
 import torch
 from torch import Tensor
-from typing import Optional, Tuple
+from typing import NamedTuple, Optional, Tuple
+
+class SpeciesCoordinates(NamedTuple):
+    species: Tensor
+    coordinates: Tensor
 
 class TorchANISpeciesConverter(torch.nn.Module):
 
@@ -37,4 +41,4 @@ class TorchANISpeciesConverter(torch.nn.Module):
 
         _, coordinates = species_coordinates
 
-        return self.species, coordinates
+        return SpeciesCoordinates(self.species, coordinates)


### PR DESCRIPTION
The mismatch was causing the README example to fail. The relevant TorchANI code is [here](https://github.com/aiqm/torchani/blob/46c554adc8b3b774c2e4172d645f456c28559d4b/torchani/nn.py#L154)

Fixes #72 