### PR TITLE
Move all torch.ops.load calls to the __init__.py scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,6 @@ install(FILES src/pytorch/__init__.py
               src/pytorch/OptimizedTorchANI.py
               src/pytorch/SpeciesConverter.py
               src/pytorch/SymmetryFunctions.py
-              src/pytorch/neighbors/__init__.py
-              src/pytorch/neighbors/getNeighborPairs.py
         DESTINATION ${Python3_SITEARCH}/${NAME})
 install(FILES src/pytorch/neighbors/__init__.py
               src/pytorch/neighbors/getNeighborPairs.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,16 +56,26 @@ foreach(TEST_PATH ${TEST_PATHS})
     add_test(${TEST_NAME} ${TEST_NAME})
 endforeach()
 
-# Tests of PyTorch wrappers
-add_test(TestBatchedNN         pytest -v ${CMAKE_SOURCE_DIR}/src/pytorch/TestBatchedNN.py)
-add_test(TestCFConv            pytest -v ${CMAKE_SOURCE_DIR}/src/pytorch/TestCFConv.py)
-add_test(TestCFConvNeighbors   pytest -v ${CMAKE_SOURCE_DIR}/src/pytorch/TestCFConvNeighbors.py)
-add_test(TestEnergyShifter     pytest -v ${CMAKE_SOURCE_DIR}/src/pytorch/TestEnergyShifter.py)
-add_test(TestOptimizedTorchANI pytest -v ${CMAKE_SOURCE_DIR}/src/pytorch/TestOptimizedTorchANI.py)
-add_test(TestSpeciesConverter  pytest -v ${CMAKE_SOURCE_DIR}/src/pytorch/TestSpeciesConverter.py)
-add_test(TestSymmetryFunctions pytest -v ${CMAKE_SOURCE_DIR}/src/pytorch/TestSymmetryFunctions.py)
-add_test(TestNeighbors         pytest -v ${CMAKE_SOURCE_DIR}/src/pytorch/neighbors/TestNeighbors.py)
-add_test(TestGetNeighborPairs  pytest -v --doctest-modules ${CMAKE_SOURCE_DIR}/src/pytorch/neighbors/getNeighborPairs.py)
+# Move test scripts to a test folder in the build directory, create test folder if necessary
+add_custom_command(TARGET ${LIBRARY} POST_BUILD	COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/test)
+add_custom_command(TARGET ${LIBRARY} POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+  ${CMAKE_SOURCE_DIR}/src/pytorch/Test*.py
+  ${CMAKE_SOURCE_DIR}/src/pytorch/neighbors/Test*.py
+  ${CMAKE_SOURCE_DIR}/src/pytorch/neighbors/getNeighborPairs.py
+  ${CMAKE_BINARY_DIR}/test)
+add_custom_command(TARGET ${LIBRARY} POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+  ${CMAKE_SOURCE_DIR}/src/pytorch/molecules
+  ${CMAKE_BINARY_DIR}/test/molecules)
+
+# Add tests for all scripts in the test directory
+file(GLOB_RECURSE PYTHON_TEST_PATHS ${CMAKE_BINARY_DIR}/test/Test*.py)
+foreach(TEST_PATH ${PYTHON_TEST_PATHS})
+		cmake_path(GET TEST_PATH STEM TEST_NAME)
+		add_test(${TEST_NAME} pytest -v ${CMAKE_BINARY_DIR}/test/${TEST_NAME}.py)
+endforeach()
+add_test(TestGetNeighborPairs  pytest -v --doctest-modules ${CMAKE_BINARY_DIR}/test/getNeighborPairs.py)
 
 # Installation
 install(TARGETS ${LIBRARY} DESTINATION ${Python3_SITEARCH}/${NAME})

--- a/src/pytorch/BatchedNN.py
+++ b/src/pytorch/BatchedNN.py
@@ -21,14 +21,12 @@
 # SOFTWARE.
 #
 
-import os
 import torch
 from torch import nn
 from torch import Tensor
 from torch.nn import functional as F
 from typing import List, NamedTuple, Tuple, Union
 
-torch.ops.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
 batchedLinear = torch.ops.NNPOpsBatchedNN.BatchedLinear
 
 

--- a/src/pytorch/CFConv.py
+++ b/src/pytorch/CFConv.py
@@ -21,14 +21,10 @@
 # SOFTWARE.
 #
 
-import os.path
 import torch
 from torch import Tensor
 
 from NNPOps.CFConvNeighbors import CFConvNeighbors
-
-torch.ops.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
-torch.classes.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
 
 class CFConv(torch.nn.Module):
     """

--- a/src/pytorch/CFConvNeighbors.py
+++ b/src/pytorch/CFConvNeighbors.py
@@ -21,11 +21,8 @@
 # SOFTWARE.
 #
 
-import os.path
 import torch
 from torch import Tensor
-
-torch.classes.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
 
 class CFConvNeighbors(torch.nn.Module):
     """

--- a/src/pytorch/SymmetryFunctions.py
+++ b/src/pytorch/SymmetryFunctions.py
@@ -21,13 +21,9 @@
 # SOFTWARE.
 #
 
-import os.path
 from typing import List, Optional, Tuple
 import torch
 from torch import Tensor
-
-torch.ops.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
-torch.classes.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
 
 Holder = torch.classes.NNPOpsANISymmetryFunctions.Holder
 operation = torch.ops.NNPOpsANISymmetryFunctions.operation

--- a/src/pytorch/__init__.py
+++ b/src/pytorch/__init__.py
@@ -12,7 +12,7 @@ for path in site.getsitepackages():
         break
 else:
     # if we didn't find it, look for NNPOps/libNNPOpsPyTorch.so in the same directory as this file
-    torch.ops.load_library(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'libNNPOpsPyTorch.so'))
+    torch.ops.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
 
 
 from NNPOps.OptimizedTorchANI import OptimizedTorchANI

--- a/src/pytorch/__init__.py
+++ b/src/pytorch/__init__.py
@@ -2,9 +2,9 @@
 High-performance PyTorch operations for neural network potentials
 '''
 import os.path
-import site
 import torch
-torch.ops.load_library(os.path.join(site.getsitepackages()[-1],"NNPOps", "libNNPOpsPyTorch.so"))
-torch.classes.load_library(os.path.join(site.getsitepackages()[-1],"NNPOps", "libNNPOpsPyTorch.so"))
+
+torch.ops.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
+torch.classes.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
 
 from NNPOps.OptimizedTorchANI import OptimizedTorchANI

--- a/src/pytorch/__init__.py
+++ b/src/pytorch/__init__.py
@@ -3,8 +3,16 @@ High-performance PyTorch operations for neural network potentials
 '''
 import os.path
 import torch
+import site
 
-torch.ops.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
-torch.classes.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
+# look for NNPOps/libNNPOpsPyTorch.so in all the paths returned by site.getsitepackages()
+for path in site.getsitepackages():
+    if os.path.exists(os.path.join(path, 'NNPOps/libNNPOpsPyTorch.so')):
+        torch.ops.load_library(os.path.join(path, 'NNPOps/libNNPOpsPyTorch.so'))
+        break
+else:
+    # if we didn't find it, look for NNPOps/libNNPOpsPyTorch.so in the same directory as this file
+    torch.ops.load_library(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'libNNPOpsPyTorch.so'))
+
 
 from NNPOps.OptimizedTorchANI import OptimizedTorchANI

--- a/src/pytorch/__init__.py
+++ b/src/pytorch/__init__.py
@@ -3,16 +3,8 @@ High-performance PyTorch operations for neural network potentials
 '''
 import os.path
 import torch
-import site
 
-# look for NNPOps/libNNPOpsPyTorch.so in all the paths returned by site.getsitepackages()
-for path in site.getsitepackages():
-    if os.path.exists(os.path.join(path, 'NNPOps/libNNPOpsPyTorch.so')):
-        torch.ops.load_library(os.path.join(path, 'NNPOps/libNNPOpsPyTorch.so'))
-        break
-else:
-    # if we didn't find it, look for NNPOps/libNNPOpsPyTorch.so in the same directory as this file
-    torch.ops.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
+torch.ops.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
 
 
 from NNPOps.OptimizedTorchANI import OptimizedTorchANI

--- a/src/pytorch/__init__.py
+++ b/src/pytorch/__init__.py
@@ -1,5 +1,10 @@
 '''
 High-performance PyTorch operations for neural network potentials
 '''
+import os.path
+import site
+import torch
+torch.ops.load_library(os.path.join(site.getsitepackages()[-1],"NNPOps", "libNNPOpsPyTorch.so"))
+torch.classes.load_library(os.path.join(site.getsitepackages()[-1],"NNPOps", "libNNPOpsPyTorch.so"))
 
 from NNPOps.OptimizedTorchANI import OptimizedTorchANI

--- a/src/pytorch/neighbors/__init__.py
+++ b/src/pytorch/neighbors/__init__.py
@@ -1,6 +1,5 @@
 '''
 Neighbor operations
 '''
-import torch
 
 from NNPOps.neighbors.getNeighborPairs import getNeighborPairs

--- a/src/pytorch/neighbors/__init__.py
+++ b/src/pytorch/neighbors/__init__.py
@@ -1,10 +1,9 @@
 '''
 Neighbor operations
 '''
-import site
-import os
+import os.path
 import torch
 
-torch.ops.load_library(os.path.join(site.getsitepackages()[-1],"NNPOps", "libNNPOpsPyTorch.so"))
+torch.ops.load_library(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'libNNPOpsPyTorch.so'))
 
 from NNPOps.neighbors.getNeighborPairs import getNeighborPairs

--- a/src/pytorch/neighbors/__init__.py
+++ b/src/pytorch/neighbors/__init__.py
@@ -1,5 +1,10 @@
 '''
 Neighbor operations
 '''
+import site
+import os
+import torch
+
+torch.ops.load_library(os.path.join(site.getsitepackages()[-1],"NNPOps", "libNNPOpsPyTorch.so"))
 
 from NNPOps.neighbors.getNeighborPairs import getNeighborPairs

--- a/src/pytorch/neighbors/__init__.py
+++ b/src/pytorch/neighbors/__init__.py
@@ -1,19 +1,6 @@
 '''
 Neighbor operations
 '''
-import os.path
 import torch
-import site
-
-# look for NNPOps/libNNPOpsPyTorch.so in all the paths returned by site.getsitepackages()
-for path in site.getsitepackages():
-    if os.path.exists(os.path.join(path, 'NNPOps/libNNPOpsPyTorch.so')):
-        torch.ops.load_library(os.path.join(path, 'NNPOps/libNNPOpsPyTorch.so'))
-        break
-else:
-    # if we didn't find it, look for NNPOps/libNNPOpsPyTorch.so in the same directory as this file
-    torch.ops.load_library(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'libNNPOpsPyTorch.so'))
-
-
 
 from NNPOps.neighbors.getNeighborPairs import getNeighborPairs

--- a/src/pytorch/neighbors/__init__.py
+++ b/src/pytorch/neighbors/__init__.py
@@ -3,7 +3,17 @@ Neighbor operations
 '''
 import os.path
 import torch
+import site
 
-torch.ops.load_library(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'libNNPOpsPyTorch.so'))
+# look for NNPOps/libNNPOpsPyTorch.so in all the paths returned by site.getsitepackages()
+for path in site.getsitepackages():
+    if os.path.exists(os.path.join(path, 'NNPOps/libNNPOpsPyTorch.so')):
+        torch.ops.load_library(os.path.join(path, 'NNPOps/libNNPOpsPyTorch.so'))
+        break
+else:
+    # if we didn't find it, look for NNPOps/libNNPOpsPyTorch.so in the same directory as this file
+    torch.ops.load_library(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'libNNPOpsPyTorch.so'))
+
+
 
 from NNPOps.neighbors.getNeighborPairs import getNeighborPairs


### PR DESCRIPTION
This PR tries to fix #68 by moving all calls to torch.ops.load to the __init__.py scripts.
