### PR TITLE
Support for pytorch 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           # Latest supported versions (with CUDA)
           - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
             enable_cuda: true
-            cuda: "11.8"
+            cuda: "11.8.0"
             gcc: "10.3.*"
             nvcc: "11.8"
             python: "3.10.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
             pytorch: "1.12.*"
 
           # Latest supported versions (with CUDA)
-          - name: Linux (CUDA 11.7, Python 3.10, PyTorch 2.0)
+          - name: Linux (CUDA 11.8.0, Python 3.10, PyTorch 2.0)
             enable_cuda: true
-            cuda: "11.7.*"
+            cuda: "11.8.0"
             gcc: "10.3.*"
             nvcc: "11.7.0"
             python: "3.10.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
             pytorch: "1.12.*"
 
           # Latest supported versions (with CUDA)
-          - name: Linux (CUDA 11.7, Python 3.10, PyTorch 2.0)
+          - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
             enable_cuda: true
-            cuda: "11.7.0"
+            cuda: "11.8.*"
             gcc: "10.3.*"
             nvcc: "11.7.0"
             python: "3.10.*"
@@ -54,7 +54,7 @@ jobs:
             enable_cuda: false
             gcc: "10.3.*"
             python: "3.10.*"
-            pytorch: "1.13.*"
+            pytorch: "2.*"
 
     steps:
     - name: Check out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install CUDA Toolkit
-      uses: Jimver/cuda-toolkit@v0.2.8
+      uses: Jimver/cuda-toolkit@v0.2.10
       with:
         cuda: ${{ matrix.cuda }}
         linux-local-args: '["--toolkit", "--override"]' 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
             pytorch: "1.12.*"
 
           # Latest supported versions (with CUDA)
-          - name: Linux (CUDA 11.7, Python 3.10, PyTorch 1.13)
+          - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
             enable_cuda: true
-            cuda: "11.7.0"
+            cuda: "11.8.*"
             gcc: "10.3.*"
-            nvcc: "11.7"
+            nvcc: "11.8.*"
             python: "3.10.*"
-            pytorch: "1.13.*"
+            pytorch: "2.*"
 
           # Latest supported versions (without CUDA)
           - name: Linux (no CUDA, Python 3.10, PyTorch 1.13)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         sed -i -e "/cudatoolkit/c\  - cudatoolkit ${{ matrix.cuda }}" \
                -e "/gxx_linux-64/c\  - gxx_linux-64 ${{ matrix.gcc }}" \
-               -e "/torchani/c\  - torchani ${{ matrix.gcc }}" \
+               -e "/torchani/c\  - torchani ${{ matrix.torchani }}" \
                -e "/nvcc_linux-64/c\  - nvcc_linux-64 ${{ matrix.nvcc }}" \
                -e "/python/c\  - python ${{ matrix.python }}" \
                -e "/pytorch-gpu/c\  - pytorch-gpu ${{ matrix.pytorch }}" \
@@ -94,7 +94,7 @@ jobs:
       run: |
         sed -i -e "/cudatoolkit/c\  # - cudatoolkit" \
                -e "/gxx_linux-64/c\  - gxx_linux-64 ${{ matrix.gcc }}" \
-               -e "/torchani/c\  - torchani ${{ matrix.gcc }}" \
+               -e "/torchani/c\  - torchani ${{ matrix.torchani }}" \
                -e "/nvcc_linux-64/c\  # - nvcc_linux-64" \
                -e "/python/c\  - python ${{ matrix.python }}" \
                -e "/pytorch-gpu/c\  - pytorch-cpu ${{ matrix.pytorch }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
             gcc: "8.5.*"
             nvcc: "10.2"
             python: "3.8.*"
+            torchani: "2.2.2"
             pytorch: "1.11.*"
 
           # Older supported versions
@@ -38,6 +39,7 @@ jobs:
             gcc: "10.3.*"
             nvcc: "11.2"
             python: "3.9.*"
+            torchani: "2.2.2"
             pytorch: "1.12.*"
 
           # Latest supported versions (with CUDA)
@@ -47,6 +49,7 @@ jobs:
             gcc: "10.3.*"
             nvcc: "11.7.0"
             python: "3.10.*"
+            torchani: "2.2.3"
             pytorch: "2.*"
 
           # Latest supported versions (without CUDA)
@@ -55,6 +58,7 @@ jobs:
             gcc: "10.3.*"
             python: "3.10.*"
             pytorch: "2.*"
+            torchani: "2.2.2"
 
     steps:
     - name: Check out
@@ -79,6 +83,7 @@ jobs:
       run: |
         sed -i -e "/cudatoolkit/c\  - cudatoolkit ${{ matrix.cuda }}" \
                -e "/gxx_linux-64/c\  - gxx_linux-64 ${{ matrix.gcc }}" \
+               -e "/torchani/c\  - torchani ${{ matrix.gcc }}" \
                -e "/nvcc_linux-64/c\  - nvcc_linux-64 ${{ matrix.nvcc }}" \
                -e "/python/c\  - python ${{ matrix.python }}" \
                -e "/pytorch-gpu/c\  - pytorch-gpu ${{ matrix.pytorch }}" \
@@ -89,6 +94,7 @@ jobs:
       run: |
         sed -i -e "/cudatoolkit/c\  # - cudatoolkit" \
                -e "/gxx_linux-64/c\  - gxx_linux-64 ${{ matrix.gcc }}" \
+               -e "/torchani/c\  - torchani ${{ matrix.gcc }}" \
                -e "/nvcc_linux-64/c\  # - nvcc_linux-64" \
                -e "/python/c\  - python ${{ matrix.python }}" \
                -e "/pytorch-gpu/c\  - pytorch-cpu ${{ matrix.pytorch }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
             pytorch: "1.12.*"
 
           # Latest supported versions (with CUDA)
-          - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
+          - name: Linux (CUDA 11.7, Python 3.10, PyTorch 2.0)
             enable_cuda: true
-            cuda: "11.8.*"
+            cuda: "11.7.*"
             gcc: "10.3.*"
             nvcc: "11.7.0"
             python: "3.10.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,11 @@ jobs:
             pytorch: "1.12.*"
 
           # Latest supported versions (with CUDA)
-          - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
+          - name: Linux (CUDA 11.7, Python 3.10, PyTorch 2.0)
             enable_cuda: true
-            cuda: "11.8.*"
+            cuda: "11.7.0"
             gcc: "10.3.*"
-            nvcc: "11.8.*"
+            nvcc: "11.7.0"
             python: "3.10.*"
             pytorch: "2.*"
 
@@ -64,7 +64,7 @@ jobs:
       uses: Jimver/cuda-toolkit@v0.2.8
       with:
         cuda: ${{ matrix.cuda }}
-        linux-local-args: '["--toolkit", "--override"]' # Need to install CUDA 10.2
+        linux-local-args: '["--toolkit", "--override"]' 
       if: ${{ matrix.enable_cuda }}
 
     - name: Install Miniconda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             gcc: "8.5.*"
             nvcc: "10.2"
             python: "3.8.*"
-            torchani: "2.2.2"
+            torchani: "2.2.*"
             pytorch: "1.11.*"
 
           # Older supported versions
@@ -39,7 +39,7 @@ jobs:
             gcc: "10.3.*"
             nvcc: "11.2"
             python: "3.9.*"
-            torchani: "2.2.2"
+            torchani: "2.2.*"
             pytorch: "1.12.*"
 
           # Latest supported versions (with CUDA)
@@ -49,7 +49,7 @@ jobs:
             gcc: "10.3.*"
             nvcc: "11.7.0"
             python: "3.10.*"
-            torchani: "2.2.3"
+            torchani: "2.2.*"
             pytorch: "2.*"
 
           # Latest supported versions (without CUDA)
@@ -58,7 +58,7 @@ jobs:
             gcc: "10.3.*"
             python: "3.10.*"
             pytorch: "2.*"
-            torchani: "2.2.2"
+            torchani: "2.2.*"
 
     steps:
     - name: Check out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,21 +43,21 @@ jobs:
             pytorch: "1.12.*"
 
           # Latest supported versions (with CUDA)
-          - name: Linux (CUDA 11.8.0, Python 3.10, PyTorch 2.0)
+          - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
             enable_cuda: true
-            cuda: "11.8.0"
+            cuda: "11.8"
             gcc: "10.3.*"
-            nvcc: "11.7.0"
+            nvcc: "11.8"
             python: "3.10.*"
             torchani: "2.2.*"
-            pytorch: "2.*"
+            pytorch: "2.0.*"
 
           # Latest supported versions (without CUDA)
-          - name: Linux (no CUDA, Python 3.10, PyTorch 1.13)
+          - name: Linux (no CUDA, Python 3.10, PyTorch 2.0)
             enable_cuda: false
             gcc: "10.3.*"
             python: "3.10.*"
-            pytorch: "2.*"
+            pytorch: "2.0.*"
             torchani: "2.2.*"
 
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,9 @@ dependencies:
   - gxx_linux-64 10.3.*
   - make
   - mdtraj
-  - nvcc_linux-64 11.8.*
-  - torchani =2.2.3
+  - nvcc_linux-64 11.8
+  - torchani =2.2.*
   - pytest
   - python 3.10.*
-  - pytorch-gpu 2.*
+  - pytorch-gpu 2.0.*
   - sysroot_linux-64 2.17

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - make
   - mdtraj
   - nvcc_linux-64 11.8
-  - torchani =2.2.*
+  - torchani 2.2.*
   - pytest
   - python 3.10.*
   - pytorch-gpu 2.0.*

--- a/environment.yml
+++ b/environment.yml
@@ -1,14 +1,16 @@
 channels:
   - conda-forge
+  - pytorch
 dependencies:
   - cmake >=3.20
-  - cudatoolkit 11.2.2
+  - cudatoolkit >=11.8
   - gxx_linux-64 10.3.*
   - make
   - mdtraj
-  - nvcc_linux-64 11.2
+  - nvcc_linux-64 >=11.8
   - torchani 2.2.2
   - pytest
   - python 3.10.*
-  - pytorch-gpu 1.12.*
+  - pytorch
+  - pytorch-gpu 2.*
   - sysroot_linux-64 2.17

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - make
   - mdtraj
   - nvcc_linux-64 11.8.*
+  - torchani =2.2.3
   - pytest
   - python 3.10.*
   - pytorch-gpu 2.*

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,13 @@
 channels:
   - conda-forge
-  - pytorch
 dependencies:
   - cmake >=3.20
-  - cudatoolkit >=11.8
+  - cudatoolkit 11.8.*
   - gxx_linux-64 10.3.*
   - make
   - mdtraj
-  - nvcc_linux-64 >=11.8
-  - torchani 2.2.2
+  - nvcc_linux-64 11.8.*
   - pytest
   - python 3.10.*
-  - pytorch
   - pytorch-gpu 2.*
   - sysroot_linux-64 2.17


### PR DESCRIPTION
This PR is to start working on making NNPOps compatible with pytorch 2.0 and torch.compile

- [x] Ensure the workflows and tests work for pytorch 2.0 (wich requires CUDA 11.8)
- [ ] Make operations compatible with torch.compile()
   Hopefully this will not require a lot of work, but reducing the number of graph breaks torch.compile will introduce will probably be more challenging. I reckon avoiding graph breaks is really similar to making stuff compatible with CUDA graphs. 
- [ ] Write tests for compiled versions
       In principle compiled functions/models should be completely equivalent to the uncompiled versions, but I have seen this not being the case (granted, torch2 was still a beta)