### PR TITLE
Make OptimizedTorchANI robust to changes to device between calls.

### DIFF
--- a/src/pytorch/OptimizedTorchANI.py
+++ b/src/pytorch/OptimizedTorchANI.py
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2020-2021 Acellera
-# Authors: Raimondas Galvelis
+# Authors: Raimondas Galvelis, Raul P. Pelaez
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,25 +30,44 @@ from NNPOps.EnergyShifter import TorchANIEnergyShifter, SpeciesEnergies
 from NNPOps.SpeciesConverter import TorchANISpeciesConverter
 from NNPOps.SymmetryFunctions import TorchANISymmetryFunctions
 
+
 class OptimizedTorchANI(torch.nn.Module):
 
-    from torchani.models import BuiltinModel # https://github.com/openmm/NNPOps/issues/44
+    from torchani.models import (
+        BuiltinModel,
+    )  # https://github.com/openmm/NNPOps/issues/44
 
     def __init__(self, model: BuiltinModel, atomicNumbers: Tensor) -> None:
 
         super().__init__()
 
         # Optimize the components of an ANI model
-        self.species_converter = TorchANISpeciesConverter(model.species_converter, atomicNumbers)
-        self.aev_computer = TorchANISymmetryFunctions(model.species_converter, model.aev_computer, atomicNumbers)
-        self.neural_networks = TorchANIBatchedNN(model.species_converter, model.neural_networks, atomicNumbers)
-        self.energy_shifter = TorchANIEnergyShifter(model.species_converter, model.energy_shifter, atomicNumbers)
+        self.species_converter = TorchANISpeciesConverter(
+            model.species_converter, atomicNumbers
+        )
+        self.aev_computer = TorchANISymmetryFunctions(
+            model.species_converter, model.aev_computer, atomicNumbers
+        )
+        self.neural_networks = TorchANIBatchedNN(
+            model.species_converter, model.neural_networks, atomicNumbers
+        )
+        self.energy_shifter = TorchANIEnergyShifter(
+            model.species_converter, model.energy_shifter, atomicNumbers
+        )
 
-    def forward(self, species_coordinates: Tuple[Tensor, Tensor],
-                cell: Optional[Tensor] = None,
-                pbc: Optional[Tensor] = None) -> SpeciesEnergies:
-
+    def forward(
+        self,
+        species_coordinates: Tuple[Tensor, Tensor],
+        cell: Optional[Tensor] = None,
+        pbc: Optional[Tensor] = None,
+    ) -> SpeciesEnergies:
         species_coordinates = self.species_converter(species_coordinates)
+        # Ensure the device of the positions is the same as the device of the rest of the input
+        # Sent second element of species_coordinates to device of first element
+        species_coordinates = (
+            species_coordinates[0],
+            species_coordinates[1].to(species_coordinates[0].device),
+        )
         species_aevs = self.aev_computer(species_coordinates, cell=cell, pbc=pbc)
         species_energies = self.neural_networks(species_aevs)
         species_energies = self.energy_shifter(species_energies)

--- a/src/pytorch/SymmetryFunctions.cpp
+++ b/src/pytorch/SymmetryFunctions.cpp
@@ -1,17 +1,17 @@
 /**
  * Copyright (c) 2020 Acellera
- * Authors: Raimondas Galvelis
- * 
+ * Authors: Raimondas Galvelis, Raul P. Pelaez
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,8 +26,8 @@
 #include "CpuANISymmetryFunctions.h"
 #include "cuda_utils.h"
 #ifdef ENABLE_CUDA
-#include <c10/cuda/CUDAStream.h>
-#include "CudaANISymmetryFunctions.h"
+    #include <c10/cuda/CUDAStream.h>
+    #include "CudaANISymmetryFunctions.h"
 #endif
 
 namespace NNPOps {
@@ -51,34 +51,77 @@ using torch::TensorOptions;
 
 class Holder : public torch::CustomClassHolder {
 public:
-    Holder(int64_t numSpecies,
-           double Rcr,
-           double Rca,
-           const vector<double>& EtaR,
-           const vector<double>& ShfR,
-           const vector<double>& EtaA,
-           const vector<double>& Zeta,
-           const vector<double>& ShfA,
-           const vector<double>& ShfZ,
-           const vector<int64_t>& atomSpecies) :
+    Holder(int64_t numSpecies, double Rcr, double Rca, const vector<double>& EtaR,
+           const vector<double>& ShfR, const vector<double>& EtaA, const vector<double>& Zeta,
+           const vector<double>& ShfA, const vector<double>& ShfZ,
+           const vector<int64_t>& atomSpecies)
+        :
 
-        torch::CustomClassHolder(),
-        numSpecies(numSpecies),
-        Rcr(Rcr), Rca(Rca),
-        EtaR(EtaR), ShfR(ShfR), EtaA(EtaA), Zeta(Zeta), ShfA(ShfA), ShfZ(ShfZ),
-        atomSpecies(atomSpecies),
-        device(torch::kCPU),
-        impl(nullptr)
-    {};
+          torch::CustomClassHolder(), numSpecies(numSpecies), Rcr(Rcr), Rca(Rca), EtaR(EtaR),
+          ShfR(ShfR), EtaA(EtaA), Zeta(Zeta), ShfA(ShfA), ShfZ(ShfZ), atomSpecies(atomSpecies){};
+
+    auto createImpl(const Tensor& positions, const optional<Tensor>& cellOpt) {
+        auto device = positions.device();
+        torch::DeviceGuard guard(device);
+        auto cellPtr = cellOpt ? cellOpt->data_ptr<float>() : nullptr;
+        int numAtoms = atomSpecies.size();
+        const vector<int> atomSpecies_(atomSpecies.begin(),
+                                       atomSpecies.end()); // vector<int64_t> --> vector<int>
+        vector<RadialFunction> radialFunctions;
+        for (const float eta : EtaR)
+            for (const float rs : ShfR)
+                radialFunctions.push_back({eta, rs});
+        this->numRadialFunctions = radialFunctions.size();
+        vector<AngularFunction> angularFunctions;
+        for (const float eta : EtaA)
+            for (const float zeta : Zeta)
+                for (const float rs : ShfA)
+                    for (const float thetas : ShfZ)
+                        angularFunctions.push_back({eta, rs, zeta, thetas});
+        this->numAngularFunctions = angularFunctions.size();
+        bool periodic = cellPtr != nullptr;
+        std::shared_ptr<::ANISymmetryFunctions> impl;
+        if (device.is_cpu()) {
+            impl = std::make_shared<CpuANISymmetryFunctions>(
+                numAtoms, numSpecies, Rcr, Rca, periodic, atomSpecies_, radialFunctions,
+                angularFunctions, true);
+#ifdef ENABLE_CUDA
+        } else if (device.is_cuda()) {
+            impl = std::make_shared<CudaANISymmetryFunctions>(
+                numAtoms, numSpecies, Rcr, Rca, periodic, atomSpecies_, radialFunctions,
+                angularFunctions, true);
+#endif
+        } else
+            throw std::runtime_error("Unsupported device: " + device.str());
+
+        return impl;
+    }
+
+    auto getImpl(Device device) {
+        std::string device_str = device.str();
+        if (this->impl_map.find(device_str) == impl_map.end()) {
+            throw std::runtime_error("No implementation for device: " + device_str);
+        }
+        return this->impl_map[device_str];
+    }
+
+#ifdef ENABLE_CUDA
+    void setCUDAStream(Device device) {
+        const CUDAStream stream = getCurrentCUDAStream(device.index());
+        dynamic_cast<CudaANISymmetryFunctions*>(getImpl(device).get())->setStream(stream.stream());
+    }
+#endif
 
     tensor_list forward(const Tensor& positions, const optional<Tensor>& cellOpt) {
-
+        auto device = positions.device();
+        torch::DeviceGuard guard(device);
         if (positions.scalar_type() != torch::kFloat32)
             throw std::runtime_error("The type of \"positions\" has to be float32");
         if (positions.dim() != 2)
             throw std::runtime_error("The shape of \"positions\" has to have 2 dimensions");
         if (positions.size(0) != atomSpecies.size())
-            throw std::runtime_error("The size of the 1nd dimension of \"positions\" has to be " + std::to_string(atomSpecies.size()));
+            throw std::runtime_error("The size of the 1nd dimension of \"positions\" has to be " +
+                                     std::to_string(atomSpecies.size()));
         if (positions.size(1) != 3)
             throw std::runtime_error("The size of the 2nd dimension of \"positions\" has to be 3");
 
@@ -86,7 +129,6 @@ public:
         float* cellPtr = nullptr;
         if (cellOpt) {
             cell = *cellOpt;
-
             if (cell.scalar_type() != torch::kFloat32)
                 throw std::runtime_error("The type of \"cell\" has to be float32");
             if (cell.dim() != 2)
@@ -96,82 +138,46 @@ public:
             if (cell.size(1) != 3)
                 throw std::runtime_error("\"cell\" has to be on the same device as \"positions\"");
             if (cell.device() != positions.device())
-                throw std::runtime_error("The device of \"cell\" has changed");
-
+                cell.to(positions.device());
             cellPtr = cell.data_ptr<float>();
         }
-
-        if (!impl) {
-            device = positions.device();
-
-            int numAtoms = atomSpecies.size();
-            const vector<int> atomSpecies_(atomSpecies.begin(), atomSpecies.end()); // vector<int64_t> --> vector<int>
-
-            vector<RadialFunction> radialFunctions;
-            for (const float eta: EtaR)
-                for (const float rs: ShfR)
-                    radialFunctions.push_back({eta, rs});
-
-            vector<AngularFunction> angularFunctions;
-            for (const float eta: EtaA)
-                for (const float zeta: Zeta)
-                    for (const float rs: ShfA)
-                        for (const float thetas: ShfZ)
-                            angularFunctions.push_back({eta, rs, zeta, thetas});
-
-            bool periodic = cellPtr != nullptr;
-
-            if (device.is_cpu()) {
-                impl = std::make_shared<CpuANISymmetryFunctions>(numAtoms, numSpecies, Rcr, Rca, periodic, atomSpecies_, radialFunctions, angularFunctions, true);
-#ifdef ENABLE_CUDA
-            } else if (device.is_cuda()) {
-                // PyTorch allow to chose GPU with "torch.device", but it doesn't set as the default one.
-                CHECK_CUDA_RESULT(cudaSetDevice(device.index()));
-                impl = std::make_shared<CudaANISymmetryFunctions>(numAtoms, numSpecies, Rcr, Rca, periodic, atomSpecies_, radialFunctions, angularFunctions, true);
-#endif
-            } else
-                throw std::runtime_error("Unsupported device: " + device.str());
-
-            const TensorOptions tensorOptions = TensorOptions().device(device); // Data type of float by default
-            radial  = torch::empty({numAtoms, numSpecies * (int)radialFunctions.size()}, tensorOptions);
-            angular = torch::empty({numAtoms, numSpecies * (numSpecies + 1) / 2 * (int)angularFunctions.size()}, tensorOptions);
-            positionsGrad = torch::empty({numAtoms, 3}, tensorOptions);
-
-#ifdef ENABLE_CUDA
-            cudaImpl = dynamic_cast<CudaANISymmetryFunctions*>(impl.get());
-#endif
+        if (this->impl_map.find(device.str()) == impl_map.end()) {
+            this->impl_map[device.str()] = createImpl(positions, cellOpt);
         }
-
-        if (positions.device() != device)
-            throw std::runtime_error("The device of \"positions\" has changed");
-
+        auto impl = getImpl(device);
 #ifdef ENABLE_CUDA
-        if (cudaImpl) {
-            const CUDAStream stream = getCurrentCUDAStream(device.index());
-            cudaImpl->setStream(stream.stream());
+        if (device.is_cuda()) {
+            this->setCUDAStream(device);
         }
 #endif
-
-        impl->computeSymmetryFunctions(positions.data_ptr<float>(), cellPtr, radial.data_ptr<float>(), angular.data_ptr<float>());
-
+        const int numAtoms = atomSpecies.size();
+        const TensorOptions tensorOptions =
+            TensorOptions().device(device); // Data type of float by default
+        Tensor radial = torch::empty({numAtoms, numSpecies * numRadialFunctions}, tensorOptions);
+        Tensor angular = torch::empty(
+            {numAtoms, numSpecies * (numSpecies + 1) / 2 * numAngularFunctions}, tensorOptions);
+        impl->computeSymmetryFunctions(positions.data_ptr<float>(), cellPtr,
+                                       radial.data_ptr<float>(), angular.data_ptr<float>());
         return {radial, angular};
     };
 
     tensor_list backward(const tensor_list& grads) {
-
         const Tensor radialGrad = grads[0].clone();
         const Tensor angularGrad = grads[1].clone();
-      
+        const auto numAtoms = radialGrad.size(0);
+        const TensorOptions tensorOptions =
+            TensorOptions().device(radialGrad.device()); // Data type of float by default
+        Tensor positionsGrad = torch::empty({numAtoms, 3}, tensorOptions);
+        auto device = grads[0].device();
 #ifdef ENABLE_CUDA
-        if (cudaImpl) {
-            const CUDAStream stream = getCurrentCUDAStream(device.index());
-            cudaImpl->setStream(stream.stream());
+        if (device.is_cuda()) {
+            this->setCUDAStream(device);
         }
 #endif
-
-        impl->backprop(radialGrad.data_ptr<float>(), angularGrad.data_ptr<float>(), positionsGrad.data_ptr<float>());
-
-        return { Tensor(), positionsGrad, Tensor() }; // empty grad for the holder and periodicBoxVectors
+        getImpl(device)->backprop(radialGrad.data_ptr<float>(), angularGrad.data_ptr<float>(),
+                                  positionsGrad.data_ptr<float>());
+        return {Tensor(), positionsGrad,
+                Tensor()}; // empty grad for the holder and periodicBoxVectors
     };
 
     static const string serialize(const HolderPtr& self) {
@@ -221,24 +227,15 @@ private:
     int numSpecies;
     double Rcr, Rca;
     vector<double> EtaR, ShfR, EtaA, Zeta, ShfA, ShfZ;
+    int numRadialFunctions, numAngularFunctions;
     vector<int64_t> atomSpecies;
-    TensorOptions tensorOptions;
-    Device device;
-    std::shared_ptr<::ANISymmetryFunctions> impl;
-    Tensor radial;
-    Tensor angular;
-    Tensor positionsGrad;
-#ifdef ENABLE_CUDA
-    CudaANISymmetryFunctions* cudaImpl;
-#endif
+    std::map<std::string, std::shared_ptr<::ANISymmetryFunctions>> impl_map;
 };
 
 class AutogradFunctions : public torch::autograd::Function<AutogradFunctions> {
 
 public:
-    static tensor_list forward(Context *ctx,
-                               const HolderPtr& holder,
-                               const Tensor& positions,
+    static tensor_list forward(Context* ctx, const HolderPtr& holder, const Tensor& positions,
                                const optional<Tensor>& periodicBoxVectors) {
 
         ctx->saved_data["holder"] = holder;
@@ -246,7 +243,7 @@ public:
         return holder->forward(positions, periodicBoxVectors);
     };
 
-    static tensor_list backward(Context *ctx, const tensor_list& grads) {
+    static tensor_list backward(Context* ctx, const tensor_list& grads) {
 
         const auto holder = ctx->saved_data["holder"].toCustomClass<Holder>();
         ctx->saved_data.erase("holder");
@@ -255,8 +252,7 @@ public:
     };
 };
 
-tensor_list operation(const optional<HolderPtr>& holder,
-                      const Tensor& positions,
+tensor_list operation(const optional<HolderPtr>& holder, const Tensor& positions,
                       const optional<Tensor>& periodicBoxVectors) {
 
     return AutogradFunctions::apply(*holder, positions, periodicBoxVectors);
@@ -277,8 +273,12 @@ TORCH_LIBRARY(NNPOpsANISymmetryFunctions, m) {
         .def("forward", &Holder::forward)
         .def("backward", &Holder::backward)
         .def_pickle(
-            [](const HolderPtr& self) -> const string { return Holder::serialize(self); }, // __getstate__
-            [](const string& state) -> HolderPtr { return Holder::deserialize(state); }    // __setstate__
+            [](const HolderPtr& self) -> const string {
+                return Holder::serialize(self);
+            }, // __getstate__
+            [](const string& state) -> HolderPtr {
+                return Holder::deserialize(state);
+            } // __setstate__
         );
     m.def("operation", operation);
 }


### PR DESCRIPTION
Solves #112.

AFAIK, the error in #112 consists of OpenMM changing the location of just the positions, which ends up with NNPOps down the line being fed tensors in two different devices.

The original reproducer by @raimis:
```python
import torch as pt
from NNPOps import OptimizedTorchANI
from openmm import Context, LocalEnergyMinimizer, Platform, System, VerletIntegrator
from openmmtorch import TorchForce
from torchani.models import ANI2x

scale = 1e10
platform = "CUDA"

class Model(pt.nn.Module):
    def __init__(self, scale):
        super().__init__()
        self.scale = scale
        self.species = pt.tensor([1, 1]).unsqueeze(0)
        self.model = ANI2x(periodic_table_index=True)
        self.model = OptimizedTorchANI(self.model, self.species)
    def forward(self, positions):
        positions = positions.unsqueeze(0).to(pt.float32)
        return self.scale * self.model.forward((self.species, positions))[1]

force = TorchForce(pt.jit.script(Model(scale)))

system = System()
system.addForce(force)
for _ in range(2):
    system.addParticle(1)

platform = Platform.getPlatformByName(platform)
context = Context(system, VerletIntegrator(1), platform)

context.setPositions([[0, 0, 0], [1, 0, 0]])
LocalEnergyMinimizer.minimize(context)
```
Is solved by simply sending the positions to the same device as the tensor with the atomic numbers (which always stays on the same device), I did this by modifying OptimizedTorchANI:
```diff
    def forward(self, species_coordinates: Tuple[Tensor, Tensor],
                 cell: Optional[Tensor] = None,
                 pbc: Optional[Tensor] = None) -> SpeciesEnergies:
 
         species_coordinates = self.species_converter(species_coordinates)
+        species_coordinates = (
+            species_coordinates[0],
+            species_coordinates[1].to(species_coordinates[0].device),
+        )
         species_aevs = self.aev_computer(species_coordinates, cell=cell, pbc=pbc)
         species_energies = self.neural_networks(species_aevs)
         species_energies = self.energy_shifter(species_energies)
 

        return species_energies
```  
In this PR, I also restructured SymmetryFunctions a bit. Instead of creating an implementation and storing it for the duration of the execution, now this class holds a map from devices to implementations, creating/fetching the necessary one according to where the positions are stored.
I did this because the positions (and only the positions) suddenly changing devices leaves us with an ambiguous decision. Do we:
1. Respect the original device the module was created with (like my fix above does) 
2. Respect the device of "positions" by doing all computations in its device
In other words, what should OptimizedTorchANI do when this assertion fails?:
```python
    def forward(
        self,
        species_coordinates: Tuple[Tensor, Tensor],
        cell: Optional[Tensor] = None,
        pbc: Optional[Tensor] = None,
    ) -> SpeciesEnergies:
        assert species_coordinates[0].device == species_coordinates[1].device
```
In the first case, we simply move positions back to the device when required.
In the second case, we must ensure every component can handle inputs with changing device.
OTOH, this makes me think: OpenMM suddenly changing the device of the positions without correctly informing NNPOps (perhaps by calling model.to(device)?) sounds to me like a bug in either OpenMM or OpenMM-Torch. 

Finally I also applied the formatter.
