### PR TITLE
Use args when calling self.aev_computer

### DIFF
--- a/src/pytorch/OptimizedTorchANI.py
+++ b/src/pytorch/OptimizedTorchANI.py
@@ -49,7 +49,7 @@ class OptimizedTorchANI(torch.nn.Module):
                 pbc: Optional[Tensor] = None) -> SpeciesEnergies:
 
         species_coordinates = self.species_converter(species_coordinates)
-        species_aevs = self.aev_computer(species_coordinates, cell=cell, pbc=pbc)
+        species_aevs = self.aev_computer(species_coordinates, cell, pbc)
         species_energies = self.neural_networks(species_aevs)
         species_energies = self.energy_shifter(species_energies)
 


### PR DESCRIPTION
This PR allows the use of a forward hook on the internal AEVComputer of ANI models when using OptmizedTorchANI via TorchScript. See aiqm/torchani#649 for details.