### PR TITLE
Load correct library name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,12 @@ set(SRC_FILES src/ani/CpuANISymmetryFunctions.cpp
 # Build the library
 set(LIBRARY ${NAME}PyTorch)
 add_library(${LIBRARY} SHARED ${SRC_FILES})
-set_property(TARGET ${LIBRARY} PROPERTY CXX_STANDARD 14)
+set_property(TARGET ${LIBRARY} PROPERTY CXX_STANDARD 17)
 target_include_directories(${LIBRARY} PRIVATE ${Python3_INCLUDE_DIRS}
                                               src/ani src/pytorch src/schnet)
 target_link_libraries(${LIBRARY} ${TORCH_LIBRARIES} ${Python3_LIBRARIES})
 if(ENABLE_CUDA)
-    set_property(TARGET ${LIBRARY} PROPERTY CUDA_STANDARD 14)
+    set_property(TARGET ${LIBRARY} PROPERTY CUDA_STANDARD 17)
     target_compile_definitions(${LIBRARY} PRIVATE ENABLE_CUDA)
 endif(ENABLE_CUDA)
 

--- a/src/pytorch/__init__.py
+++ b/src/pytorch/__init__.py
@@ -2,9 +2,16 @@
 High-performance PyTorch operations for neural network potentials
 '''
 import os.path
+import platform
 import torch
 
-torch.ops.load_library(os.path.join(os.path.dirname(__file__), 'libNNPOpsPyTorch.so'))
+if platform.system() == 'Darwin':
+    libname = 'libNNPOpsPyTorch.dylib'
+elif platform.system() == 'Windows':
+    libname = 'NNPOpsPyTorch.dll'
+else:
+    libname = 'libNNPOpsPyTorch.so'
+torch.ops.load_library(os.path.join(os.path.dirname(__file__), libname))
 
 
 from NNPOps.OptimizedTorchANI import OptimizedTorchANI


### PR DESCRIPTION
Fixes #102.

I also updated the build script to specify C++17, since the latest version of PyTorch requires it.